### PR TITLE
Update to wkhtmltopdf 0.12.2

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,7 @@ BIN_PATH="$1/bin"
 TMP_PATH="$1/tmp"
 mkdir -p $BIN_PATH $TMP_PATH
 
-WKHTMLTOPDF_URL="http://downloads.sourceforge.net/project/wkhtmltopdf/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb"
+WKHTMLTOPDF_URL="http://downloads.sourceforge.net/project/wkhtmltopdf/0.12.2/wkhtmltox-0.12.2_linux-trusty-amd64.deb"
 WKHTMLTOPDF_PKG="$TMP_PATH/wkhtmltopdf.deb"
 WKHTMLTOPDF_PATH="$TMP_PATH/wkhtmltopdf"
 WKHTMLTOPDF_BINARIES="$WKHTMLTOPDF_PATH/usr/local/bin"


### PR DESCRIPTION
The previous `0.12.1` archives were removed from SouceForge, so the current version of the buildpack won't work without this change.