### PR TITLE
Use CACHE_DIR to avoid downloading on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,14 @@ $ git add .buildpacks
 $ git commit -m 'Add multi-buildpack'
 ```
 
-[0]: http://devcenter.heroku.com/articles/buildpacks
-[1]: http://wkhtmltopdf.org/
+### Clearing Repo Cache
+
+Remember to clean your repository cache if you are updating the version of buildpack. To do that, run:
+
+```bash
+$ heroku plugins:install https://github.com/heroku/heroku-repo.git
+$ heroku repo:purge_cache -a appname
+```
 
 ## Troubleshooting
 
@@ -35,3 +41,6 @@ If you are on an older stack, you can upgrade to `cedar-14` with:
 ```bash
 $ heroku stack:set cedar-14
 ```
+
+[0]: http://devcenter.heroku.com/articles/buildpacks
+[1]: http://wkhtmltopdf.org/

--- a/bin/compile
+++ b/bin/compile
@@ -1,21 +1,29 @@
 #!/usr/bin/env bash
+# bin/compile <build-dir> <cache-dir>
 
 set -e
 
-BIN_PATH="$1/bin"
-TMP_PATH="$1/tmp"
-mkdir -p $BIN_PATH $TMP_PATH
+BUILD_DIR=$1
+CACHE_DIR=$2
+
+BIN_PATH="$BUILD_DIR/bin"
+TMP_PATH="$BUILD_DIR/tmp"
+mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
 
 WKHTMLTOPDF_URL="http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb"
-WKHTMLTOPDF_PKG="$TMP_PATH/wkhtmltopdf.deb"
+WKHTMLTOPDF_PKG="$CACHE_DIR/wkhtmltopdf.deb"
 WKHTMLTOPDF_PATH="$TMP_PATH/wkhtmltopdf"
 WKHTMLTOPDF_BINARIES="$WKHTMLTOPDF_PATH/usr/local/bin"
 
 BIN_DIR=$(cd $(dirname $0); pwd)
 FONTS_DIR=$(cd "$BIN_DIR/../fonts"; pwd)
 
-echo "-----> Downloading wkhtmltopdf Debian package"
-curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
+if [ -f $WKHTMLTOPDF_PKG ]; then
+  echo "-----> Using wkhtmltopdf Debian package from cache"
+else
+  echo "-----> Downloading wkhtmltopdf Debian package"
+  curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
+fi
 
 echo "-----> Unpacking Debian package"
 dpkg -x $WKHTMLTOPDF_PKG $WKHTMLTOPDF_PATH
@@ -27,7 +35,7 @@ echo "-----> Moving binaries to the right place"
 mv $WKHTMLTOPDF_BINARIES/* $BIN_PATH/
 
 echo "-----> Cleaning up"
-rm -rf $WKHTMLTOPDF_PKG $WKHTMLTOPDF_PATH
+rm -rf $WKHTMLTOPDF_PATH
 
 echo "-----> Installing fonts"
 mkdir -p $1/.fonts


### PR DESCRIPTION
Leverage [Heroku's `CACHE_DIR`](https://devcenter.heroku.com/articles/buildpack-api#caching) to avoid downloading the wkhtmltopdf debian package on every deploy. Also added instructions to the `README` to clear the cache.

I have tested this on one of our apps and it's :+1:.