### PR TITLE
Use a working distribution URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # wkhtmltopdf Buildpack
 
-This is a [Heroku buildpack][0] for bundling a compatible [wkhtmltopdf][1] binary with your environment.
+This is a [Heroku buildpack][0] for bundling a compatible [wkhtmltopdf][1]
+binary with your environment.
 
 ## Versions
 
 * Buildpack:   `0.2`
-* wkhtmltopdf: `0.12.2.1`
+* wkhtmltopdf: `0.12.4`
 
 ## Usage
 
-This buildpack only installs wkhtmltopdf, it isn't very useful by itself. You'll probably want to use it as part of a multi-buildpack. Here is an example using the Ruby buildpack.
+This buildpack only installs wkhtmltopdf, it isn't very useful by itself. You'll
+probably want to use it as part of a multi-buildpack. Here is an example using
+the Ruby buildpack.
 
 ```bash
 $ heroku buildpacks:set 'https://github.com/heroku/heroku-buildpack-multi.git'
@@ -21,7 +24,8 @@ $ git commit -m 'Add multi-buildpack'
 
 ### Clearing Repo Cache
 
-Remember to clean your repository cache if you are updating the version of buildpack. To do that, run:
+Remember to clean your repository cache if you are updating the version of
+buildpack. To do that, run:
 
 ```bash
 $ heroku plugins:install https://github.com/heroku/heroku-repo.git
@@ -30,16 +34,11 @@ $ heroku repo:purge_cache -a appname
 
 ## Troubleshooting
 
-If you run into issues when trying to deploy with this buildpack, make sure your app is running on Cedar with Ubuntu 14.04 (`cedar-14`). You can check this with:
+If you run into issues when trying to deploy with this buildpack, make sure your
+app is running on `cedar-14` or `heroku-16`. You can check this with:
 
 ```bash
 $ heroku stack
-```
-
-If you are on an older stack, you can upgrade to `cedar-14` with:
-
-```bash
-$ heroku stack:set cedar-14
 ```
 
 [0]: http://devcenter.heroku.com/articles/buildpacks

--- a/bin/compile
+++ b/bin/compile
@@ -10,23 +10,23 @@ BIN_PATH="$BUILD_DIR/bin"
 TMP_PATH="$BUILD_DIR/tmp"
 mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
 
-WKHTMLTOPDF_URL="http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb"
-WKHTMLTOPDF_PKG="$CACHE_DIR/wkhtmltopdf.deb"
-WKHTMLTOPDF_PATH="$TMP_PATH/wkhtmltopdf"
-WKHTMLTOPDF_BINARIES="$WKHTMLTOPDF_PATH/usr/local/bin"
+WKHTMLTOPDF_URL="https://downloads.wkhtmltopdf.org/0.12/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz"
+WKHTMLTOPDF_TAR="$CACHE_DIR/wkhtmltox.tar.xz"
+WKHTMLTOPDF_PATH="$TMP_PATH/wkhtmltox"
+WKHTMLTOPDF_BINARIES="$WKHTMLTOPDF_PATH/bin"
 
 BIN_DIR=$(cd $(dirname $0); pwd)
 FONTS_DIR=$(cd "$BIN_DIR/../fonts"; pwd)
 
-if [ -f $WKHTMLTOPDF_PKG ]; then
-  echo "-----> Using wkhtmltopdf Debian package from cache"
+if [ -f $WKHTMLTOPDF_TAR ]; then
+  echo "-----> Using wkhtmltopdf tar from cache"
 else
-  echo "-----> Downloading wkhtmltopdf Debian package"
-  curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
+  echo "-----> Downloading wkhtmltopdf tar"
+  curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_TAR
 fi
 
-echo "-----> Unpacking Debian package"
-dpkg -x $WKHTMLTOPDF_PKG $WKHTMLTOPDF_PATH
+echo "-----> Unpacking tar"
+tar -xf $WKHTMLTOPDF_TAR -C $TMP_PATH
 
 echo "-----> Setting permissions"
 chmod +x $WKHTMLTOPDF_BINARIES/*


### PR DESCRIPTION
The old `gna` host is shutting down and the hosting situation has changed. As part of that, there are no longer `deb` distributions for anything but the bleeding edge, so we are now using a statically linked generic binary for linux/amd64.