### PR TITLE
Revert "Detect cedar-14 stack, or fail"

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,9 +1,4 @@
 #!/usr/bin/env bash
 
-# This buildpack is valid only for the cedar-14 stack
-if [ "$STACK" = "cedar-14" ]; then
-  echo "wkhtmltopdf-buildpack"
-  exit 0
-else
-  exit 1
-fi
+echo "wkhtmltopdf-buildpack"
+exit 0


### PR DESCRIPTION
This reverts commit 4581d0f07421603aef31a80b3e5b37ea2e2d40d0.

This change broke the buildpack upon release of the [heroku-16 stack](https://devcenter.heroku.com/articles/heroku-16-stack). In
lieu of an issue with a particular stack, we may want to remain open
to deployment to new stacks without requiring a change to the buildpack.

See https://github.com/dscout/wkhtmltopdf-buildpack/pull/16.