### PR TITLE
Allow using different version of wkhtmltopdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ binary with your environment.
 ## Versions
 
 * Buildpack:   `0.2`
-* wkhtmltopdf: `0.12.4`
+* wkhtmltopdf: `0.12.3` by default
 
 ## Usage
 
@@ -20,6 +20,13 @@ $ echo 'https://github.com/heroku/heroku-buildpack-ruby.git' >> .buildpacks
 $ echo 'https://github.com/dscout/wkhtmltopdf-buildpack.git' >> .buildpacks
 $ git add .buildpacks
 $ git commit -m 'Add multi-buildpack'
+```
+
+If you want to use a wkhtmltopdf version other than 0.12.3, set
+`WKHTMLTOPDF_VERSION`:
+
+```bash
+heroku config:set WKHTMLTOPDF_VERSION="0.12.4"
 ```
 
 ### Clearing Repo Cache

--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,8 @@ BIN_PATH="$BUILD_DIR/bin"
 TMP_PATH="$BUILD_DIR/tmp"
 mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
 
-WKHTMLTOPDF_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz"
+[ -z "$WKHTMLTOPDF_VERSION" ] && WKHTMLTOPDF_VERSION="0.12.3"
+WKHTMLTOPDF_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox-${WKHTMLTOPDF_VERSION}_linux-generic-amd64.tar.xz"
 WKHTMLTOPDF_TAR="$CACHE_DIR/wkhtmltox.tar.xz"
 WKHTMLTOPDF_PATH="$TMP_PATH/wkhtmltox"
 WKHTMLTOPDF_BINARIES="$WKHTMLTOPDF_PATH/bin"


### PR DESCRIPTION
Adds an env var to set the version of wkhtmltopdf. It defaults to 0.12.3 because there is a regression in 0.12.4.

Closes #24 