### PR TITLE
Eval WKHTMLTOPDF_VERSION with bash conditional

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,12 +5,18 @@ set -e
 
 BUILD_DIR=$1
 CACHE_DIR=$2
+ENV_DIR=$3
 
 BIN_PATH="$BUILD_DIR/bin"
 TMP_PATH="$BUILD_DIR/tmp"
 mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
 
-[ -z "$WKHTMLTOPDF_VERSION" ] && WKHTMLTOPDF_VERSION="0.12.3"
+if [[ -f "$ENV_DIR/WKHTMLTOPDF_VERSION" ]]; then
+  WKHTMLTOPDF_VERSION=$(cat "$ENV_DIR/WKHTMLTOPDF_VERSION")
+else
+  WKHTMLTOPDF_VERSION="0.12.3"
+fi
+
 WKHTMLTOPDF_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox-${WKHTMLTOPDF_VERSION}_linux-generic-amd64.tar.xz"
 WKHTMLTOPDF_TAR="$CACHE_DIR/wkhtmltox.tar.xz"
 WKHTMLTOPDF_PATH="$TMP_PATH/wkhtmltox"


### PR DESCRIPTION
The current bash code `[ -z "$WKHTMLTOPDF_VERSION" ] && WKHTMLTOPDF_VERSION="0.12.3"` isn't working, it doesn't set the WKHTMLTOPDF_VERSION because the environment variables are not being received.

According to the heroku buildpack documentation the environment variables are sent as a 3rd argument to `compile`, in this case `ENV_DIR=$3`. Check [Heroku Buildpack API - Usage](https://devcenter.heroku.com/articles/buildpack-api#bin-compile-usage)

I did test the patch and it seems to be working fine, with or without WKHTMLTOPDF_VERSION variable.

Thanks a lot for your buildpack.