### PR TITLE
Install libwkhtmltox library

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ binary with your environment.
 ## Usage
 
 [Add this buildpack][2] to your Heroku application to install the `wkhtmltopdf`
-binary into the dynos:
+and `wkhtmltoimage` binaries, and the corresponding library `libwkhtmltox`,
+into the dynos:
 
 ```bash
 $ heroku buildpacks:add https://github.com/dscout/wkhtmltopdf-buildpack.git

--- a/bin/compile
+++ b/bin/compile
@@ -8,8 +8,9 @@ CACHE_DIR=$2
 ENV_DIR=$3
 
 BIN_PATH="$BUILD_DIR/bin"
+LIB_PATH="$BUILD_DIR/vendor/wkhtmltox/lib"
 TMP_PATH="$BUILD_DIR/tmp"
-mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
+mkdir -p $CACHE_DIR $BIN_PATH $LIB_PATH $TMP_PATH
 
 if [[ -f "$ENV_DIR/WKHTMLTOPDF_VERSION" ]]; then
   WKHTMLTOPDF_VERSION=$(cat "$ENV_DIR/WKHTMLTOPDF_VERSION")
@@ -21,6 +22,7 @@ WKHTMLTOPDF_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${
 WKHTMLTOPDF_TAR="$CACHE_DIR/wkhtmltox.tar.xz"
 WKHTMLTOPDF_PATH="$TMP_PATH/wkhtmltox"
 WKHTMLTOPDF_BINARIES="$WKHTMLTOPDF_PATH/bin"
+WKHTMLTOPDF_LIBS="$WKHTMLTOPDF_PATH/lib"
 
 BIN_DIR=$(cd $(dirname $0); pwd)
 FONTS_DIR=$(cd "$BIN_DIR/../fonts"; pwd)
@@ -40,6 +42,9 @@ chmod +x $WKHTMLTOPDF_BINARIES/*
 
 echo "-----> Moving binaries to the right place"
 mv $WKHTMLTOPDF_BINARIES/* $BIN_PATH/
+
+echo "-----> Moving libs to the right place"
+mv $WKHTMLTOPDF_LIBS/* $BIN_PATH/
 
 echo "-----> Cleaning up"
 rm -rf $WKHTMLTOPDF_PATH

--- a/bin/compile
+++ b/bin/compile
@@ -44,7 +44,7 @@ echo "-----> Moving binaries to the right place"
 mv $WKHTMLTOPDF_BINARIES/* $BIN_PATH/
 
 echo "-----> Moving libs to the right place"
-mv $WKHTMLTOPDF_LIBS/* $BIN_PATH/
+mv $WKHTMLTOPDF_LIBS/* $LIB_PATH/
 
 echo "-----> Cleaning up"
 rm -rf $WKHTMLTOPDF_PATH


### PR DESCRIPTION
In addition to the binaries (wkhtmltoimage and wkhtmltopdf), the release package contains a library version of the applications, called libwkhtmltox. There are simple but useful api docs for the library on the [project page](https://wkhtmltopdf.org/libwkhtmltox/).

This PR updates the compile script to install the library as well as the binaries. The library is installed in $BUILD_DIR/vendor/wkhtmltox/lib.